### PR TITLE
Refactor to use canvas only

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,7 +2,11 @@
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;
-  text-align: center;
+}
+
+canvas {
+  width: 100%;
+  height: auto;
 }
 
 .logo {


### PR DESCRIPTION
Hola,

Estuve hace algunas horas en tu stream de twitch como kiyoma_85.

Este PR esta refactorizado para utilizar únicamente el canvas para colocar la imágen y el sticker.  Esto simplifica bastantes cosas y resuelve el problema de que se posicione mal el sticker al cambiar el tamaño de la venta. 

Revisalo y espero te sea de utilidad.

PD:  No soy usuario de React (Uso Angular, Svelte, Vue, AstroJS) así que resolver esto me ha sido de utilidad para conocer un poco mas de la libreria de React que pues, no cae mal aprender.